### PR TITLE
Fix code highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,9 @@ const ColorPlugin = require('editorjs-text-color-plugin');
 ```
 
 ### Load from CDN
+```html
 <script src="https://cdn.jsdelivr.net/npm/editorjs-text-color-plugin@1.1.22/dist/bundle.js"></script>
+```
 
 ## Usage
 


### PR DESCRIPTION
The CDN was hidden from the npmjs.com page (likely due to sanitization).
This should solve the issue.