### PR TITLE
Add Default Options for Color Picker Custom Element Class

### DIFF
--- a/src/picker/index.js
+++ b/src/picker/index.js
@@ -14,7 +14,7 @@ class ColorPlugin extends HTMLElement {
 
     static get observedAttributes() { return ['disabled','dir'] }
 
-    constructor(options) {
+    constructor(options = {}) {
         super();
         const shadowRoot = this.attachShadow({ mode: 'open' });
         this.colorCollections = options.colorCollections || ColorCollections;


### PR DESCRIPTION
We are experiencing an error when the custom element for the Color Picker is being cloned. It's a bit of a long story, but we are using Turbo Drive which calls `cloneNode` and we cannot easily prevent it. Since this is a custom element, I think it's a reasonable expectation it should support the `HTMLElement` helpers.

This error can be reproduced in a browser by selecting the `xy-color-picker` custom element in the respective "Elements" tab. Then going to the JavaScript "Console" and typing `$0.cloneNode()` where `$0` is a reference to that element (Chrome devtools).

![image](https://github.com/flaming-cl/editorjs-text-color-plugin/assets/5247455/6f8f9c1b-016e-4c75-a391-88e1534bb817)

This errors because `cloneNode` is constructing the element without any arguments, which this constructor assumes.

This PR addresses this error by defaulting `options` to `{}` which avoids `options` being undefined.